### PR TITLE
fix: fix for "bcrypt_lib.node: invalid ELF header"

### DIFF
--- a/udacity-c3-restapi-user/.dockerignore
+++ b/udacity-c3-restapi-user/.dockerignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Would only see the error when running the docker image